### PR TITLE
chore(renovate): enable automerge for non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,15 @@
   "prBodyNotes": ["cc @skulidropek"],
 
   "prConcurrentLimit": 1,
-  "prHourlyLimit": 1
+  "prHourlyLimit": 1,
+
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "description": "Automerge non-major updates when CI is green",
+      "matchUpdateTypes": ["minor", "patch", "digest", "lockFileMaintenance"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
+  ]
 }


### PR DESCRIPTION
Enables Renovate automerge for non-major updates (minor/patch/digest/lockFileMaintenance) when CI is green.

Notes:
- Uses platform auto-merge (GitHub). Ensure repo setting 'Allow auto-merge' is enabled.
- To guarantee 'green-only' merges, enable branch protection on main with required status checks.